### PR TITLE
Update: Gnome 49 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "TodoZen",
   "description": "Fork of 'todoit-gnome' by Wassim Ben Jdida (@wassimbj) — enhanced with task renaming, confirm deletion prompt and improved UX (v3.0.0)",
   "uuid": "todozen@irtesaam.github.io",
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "url": "https://github.com/Irtesaam/todozen",
   "settings-schema": "org.gnome.shell.extensions.todozen",
   "version": 3

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -522,7 +522,7 @@ export default class TodoListExtension extends Extension {
 
         if (scrollToTop) {
             // Scroll to top to make the confirmation visible
-            this.scrollView?.get_vscroll_bar()?.get_adjustment()?.set_value(0);
+            this.scrollView?.vadjustment?.set_value(0);
         }
 
         // Clear previous timeout if any


### PR DESCRIPTION
Tested on GNOME 49. Only metadata.json needed updating. No API breaking changes per the [gjs.guide porting guide](https://gjs.guide/extensions/upgrading/gnome-shell-49.html), plus the vadjustment fix.

### Changes
 - metadata.json: add "49" to shell-version
 - src/extension.js: get_vscroll_bar()?.get_adjustment()? -> vadjustment